### PR TITLE
Fix Typo 

### DIFF
--- a/functions/star-wars-api/function.ts
+++ b/functions/star-wars-api/function.ts
@@ -4,7 +4,7 @@ export default async ({ parameters, api }: IFunctionExecutionArguments) => {
     /**
      * The parameters-object contains the parameters with which
      * this instances of your Function was started. The
-     * data can be accesed and used for data-exchange with e.g.
+     * data can be accessed and used for data-exchange with e.g.
      * your calling Flow.
      */
     const { path, index } = parameters;


### PR DESCRIPTION
I found a teeny tiny typo in the docstring for the default Function function.

I realize this should be changed "upstream" / in the online editor, but documenting here!